### PR TITLE
MAGENTO2-177 Exception thrown when config.php is being imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
  - Empty implementation of the cron action
 ### Changed
  - Uses Shopgate Cart Integration SDK 2.9.74
+### Fixed
+ - Issue importing config.php when CMS Map config is empty
 ### Removed
  - Import of prefixes in customer addresses
 

--- a/src/Model/Source/CmsMap/ArraySerialized.php
+++ b/src/Model/Source/CmsMap/ArraySerialized.php
@@ -92,16 +92,16 @@ class ArraySerialized extends MageArraySerialized
      */
     public function beforeSave()
     {
-        /** @var array $oldValues */
         $oldValues = $this->getValue();
-        $newValues = $this->removeDuplicates($oldValues);
-
-        if (count($oldValues) !== count($newValues)) {
-            /** @noinspection PhpParamsInspection */
-            $this->setValue($newValues);
-            $this->messageManager->addWarningMessage(
-                __('Same page was assigned a URL Key multiple times! Duplicate entries were removed.')
-            );
+        if (is_array($oldValues)) {
+            $newValues = $this->removeDuplicates($oldValues);
+            if (count($oldValues) !== count($newValues)) {
+                /** @noinspection PhpParamsInspection */
+                $this->setValue($newValues);
+                $this->messageManager->addWarningMessage(
+                    __('Same page was assigned a URL Key multiple times! Duplicate entries were removed.')
+                );
+            }
         }
 
         return parent::beforeSave();

--- a/src/Model/Source/CmsMap/ArraySerialized.php
+++ b/src/Model/Source/CmsMap/ArraySerialized.php
@@ -60,10 +60,10 @@ class ArraySerialized extends MageArraySerialized
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
         ManagerInterface $messageManager,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
         Cache $sgCache,
         Encoder $encoder,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->messageManager = $messageManager;


### PR DESCRIPTION
## Description

When config.php has our shopgate_base/general/cms_map set to null or empty, it will throw an exception when being imported via `bin/magento app:config:import`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
