### PR TITLE
MAGENTO2-192: fixed missing product in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Order import when ordering a product more than once with different custom option values
 
 ## [2.9.11] - 2019-02-13
 ### Added

--- a/src/Helper/Quote.php
+++ b/src/Helper/Quote.php
@@ -193,6 +193,12 @@ class Quote
 
                 $quoteItem->setRowWeight($quoteItem->getWeight() * $quoteItem->getQty());
                 $this->quote->setItemsCount($this->quote->getItemsCount() + 1);
+
+                /**
+                 * Magento's flow is to save Quote on addItem, then on saveOrder load quote again. We mimic this here.
+                 */
+                $this->quoteRepository->save($this->quote);
+                $this->quote = $this->quoteRepository->get($this->quote->getId());
             } catch (\Exception $e) {
                 $this->log->error(
                     "Error importing product to quote by id: {$product->getId()}, error: {$e->getMessage()}"
@@ -201,12 +207,6 @@ class Quote
                 $item->setMagentoError($e->getMessage());
             }
         }
-
-        /**
-         * Magento's flow is to save Quote on addItem, then on saveOrder load quote again. We mimic this here.
-         */
-        $this->quoteRepository->save($this->quote);
-        $this->quote = $this->quoteRepository->get($this->quote->getId());
     }
 
     /**

--- a/src/Model/Shopgate/Extended/Base.php
+++ b/src/Model/Shopgate/Extended/Base.php
@@ -105,7 +105,7 @@ class Base extends \ShopgateOrder
 
             $item = $this->itemFactory->create();
             $item->loadArray($element);
-            $items[$item->getItemNumber()] = $item;
+            $items[$item->getOrderItemId()] = $item;
         }
 
         $this->items = $items;


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed order import when ordering a product more than once with different custom option values.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
