### PR TITLE
MAGENTO2-647: do not export inactive child products anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Inactive child products are not exported anymore
+
 ## [2.9.22] - 2020-02-05
 ### Added
 - support for regions based on text input fields
-
+:wq!:wq!
 ## [2.9.21] - 2019-11-26
 ### Added
 - Security enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2.9.22] - 2020-02-05
 ### Added
 - support for regions based on text input fields
-:wq!:wq!
+
 ## [2.9.21] - 2019-11-26
 ### Added
 - Security enhancements

--- a/src/Helper/Product/Type/Configurable.php
+++ b/src/Helper/Product/Type/Configurable.php
@@ -23,6 +23,7 @@
 namespace Shopgate\Base\Helper\Product\Type;
 
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Quote\Model\Quote\Item;
 
 class Configurable extends Generic
@@ -70,6 +71,7 @@ class Configurable extends Generic
         $productCollection->addAttributeToFilter('entity_id', ['in' => $childProductIds]);
         $productCollection->addStoreFilter();
         $productCollection->addAttributeToSelect('*');
+        $productCollection->addAttributeToFilter('status', array('eq' => Status::STATUS_ENABLED));
 
         return $productCollection;
     }

--- a/src/Helper/Product/Type/Configurable.php
+++ b/src/Helper/Product/Type/Configurable.php
@@ -71,7 +71,7 @@ class Configurable extends Generic
         $productCollection->addAttributeToFilter('entity_id', ['in' => $childProductIds]);
         $productCollection->addStoreFilter();
         $productCollection->addAttributeToSelect('*');
-        $productCollection->addAttributeToFilter('status', array('eq' => Status::STATUS_ENABLED));
+        $productCollection->addAttributeToFilter('status', ['eq' => Status::STATUS_ENABLED]);
 
         return $productCollection;
     }

--- a/src/Helper/Product/Type/Grouped.php
+++ b/src/Helper/Product/Type/Grouped.php
@@ -54,7 +54,7 @@ class Grouped extends Generic
         $productCollection->addAttributeToFilter('entity_id', ['in' => $associatedProductIds]);
         $productCollection->addStoreFilter();
         $productCollection->addAttributeToSelect('*');
-        $productCollection->addAttributeToFilter('status', array('eq' => Status::STATUS_ENABLED));
+        $productCollection->addAttributeToFilter('status', ['eq' => Status::STATUS_ENABLED]);
 
         return $productCollection;
     }

--- a/src/Helper/Product/Type/Grouped.php
+++ b/src/Helper/Product/Type/Grouped.php
@@ -24,6 +24,7 @@ namespace Shopgate\Base\Helper\Product\Type;
 
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product as MageProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\GroupedProduct\Model\Product\Type\Grouped as MageGrouped;
 
 class Grouped extends Generic
@@ -53,6 +54,7 @@ class Grouped extends Generic
         $productCollection->addAttributeToFilter('entity_id', ['in' => $associatedProductIds]);
         $productCollection->addStoreFilter();
         $productCollection->addAttributeToSelect('*');
+        $productCollection->addAttributeToFilter('status', array('eq' => Status::STATUS_ENABLED));
 
         return $productCollection;
     }


### PR DESCRIPTION
# Pull Request Template

## Description

We used to export also inactive child products for configurable and grouped products.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
