### PR TITLE
update composer dependency, fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-## [2.9.24] - 2020-07-24
 ### Added
 - Quote to checkout session
 - Support for custom product prices during check_cart and add_order
+- Compatibility with Magento 2.4
+
+## [2.9.24] - 2020-07-24
+### Added
 - mapping for name prefix
 - quote to checkout session
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Shopgate base module for Magento 2, handles communication with merchant API and routing calls",
   "license": "Apache-2.0",
   "type": "magento2-module",
-  "version": "2.9.24",
+  "version": "2.9.25-rc.1",
   "authors": [
     {
       "name": "Konstantin Kiritsenko"
@@ -25,7 +25,7 @@
     "php": ">=7.1",
     "shopgate/cart-integration-sdk": "2.9.78",
     "magento/module-grouped-product": "^100.0",
-    "magento/module-bundle": "^100.0",
+    "magento/module-bundle": ">=100.0 <102.0",
     "magento/module-configurable-product": "^100.0"
   },
   "autoload": {


### PR DESCRIPTION
# Pull Request Template

## Description

Let merchants update to magento 2.4 without dropping this plugin

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
