### PR TITLE
fix issue with proxy classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Fixed
-- static reference to a private const, which caused problems when the class is extended
+- `private` access to class constants that need to be accessible by child classes are now `protected`
 
 ## [2.9.25] - 2020-11-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- static reference to a private const, which caused problems when the class is extended
+
 ## [2.9.25] - 2020-11-19
 ### Added
 - quote to checkout session

--- a/src/Block/Adminhtml/Form/Field/MagentoPrefix.php
+++ b/src/Block/Adminhtml/Form/Field/MagentoPrefix.php
@@ -34,8 +34,8 @@ use Magento\Store\Model\ScopeInterface;
  */
 class MagentoPrefix extends Select
 {
-    private const PREFIX_CONFIG_PATH = 'customer/address/prefix_options';
-    private const PREFIX_DELIMITER   = ';';
+    protected const PREFIX_CONFIG_PATH = 'customer/address/prefix_options';
+    protected const PREFIX_DELIMITER   = ';';
 
     /** @var Context */
     private $context;


### PR DESCRIPTION
# Pull Request Template

## Description

private const is not defined, when referenced with static::const in a class extension

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
