### PR TITLE
SG-76: switch to laminas serializer

### DIFF
--- a/.github/workflows/check_and_deploy.yml
+++ b/.github/workflows/check_and_deploy.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Code Style
         run: |
-          curl -L https://cs.symfony.com/download/php-cs-fixer-v2.phar -o php-cs-fixer
+          curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.4.0/php-cs-fixer.phar -o php-cs-fixer
           chmod a+x php-cs-fixer
           ./php-cs-fixer fix --config=.php-cs.dist --cache-file=.php-cs.cache --diff --dry-run --verbose
 

--- a/.github/workflows/check_and_deploy.yml
+++ b/.github/workflows/check_and_deploy.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.4.0/php-cs-fixer.phar -o php-cs-fixer
           chmod a+x php-cs-fixer
-          ./php-cs-fixer fix --config=.php-cs.dist --cache-file=.php-cs.cache --diff --dry-run --verbose
+          ./php-cs-fixer fix --config=.php-cs-fixer.dist.php --cache-file=.php-cs-fixer.cache --diff --dry-run --verbose
 
   deploy:
     name: Deploy to GitHub

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,9 +11,6 @@ use PhpCsFixer\Finder;
 $fixers = array(
     '@PSR1' => true,
     '@PSR2' => true,
-    'array_syntax' => array(
-        'syntax' => 'short',
-    ),
     'blank_line_after_opening_tag' => true,
     'method_argument_space' => false,
 );
@@ -23,8 +20,10 @@ $finder = Finder::create()
                 ->exclude('release')
                 ->in(__DIR__);
 
-return Config::create()
-             ->setRiskyAllowed(true)
-             ->setUsingCache(true)
-             ->setRules($fixers)
-             ->setFinder($finder);
+$config = new Config();
+$config->setRiskyAllowed(true)
+       ->setUsingCache(true)
+       ->setRules($fixers)
+       ->setFinder($finder);
+
+return $config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Using Laminas Serializer instead of Zend
 
 ## [2.9.28] - 2021-09-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Changed
-- Using Laminas Serializer instead of Zend
+- uses Laminas serializer instead of Zend
 
 ## [2.9.28] - 2021-09-01
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "shopgate/cart-integration-sdk": "2.9.82",
     "magento/module-grouped-product": "^100.0",
     "magento/module-bundle": ">=100.0 <102.0",
-    "magento/module-configurable-product": "^100.0"
+    "magento/module-configurable-product": "^100.0",
+    "laminas/laminas-serializer": "^2.7.2"
   },
   "autoload": {
     "files": [

--- a/src/Helper/Quote.php
+++ b/src/Helper/Quote.php
@@ -41,7 +41,7 @@ use Shopgate\Base\Model\Shopgate\Extended;
 use Shopgate\Base\Model\Utility\Registry;
 use Shopgate\Base\Model\Utility\SgLoggerInterface;
 use ShopgateLibraryException;
-use \Zend\Serializer\Serializer;
+use Laminas\Serializer\Serializer;
 
 /**
  * This class must not return anything except itself as it only


### PR DESCRIPTION
# Pull Request Template

## Description

The Laminas Serializer has been removed from the composer.json of Magento 2.4.3 as a result even the laminas/laminas-zendframework-bridge package could not fix the Zend vs. Laminas issue anymore.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
