### PR TITLE
don't set shopgate Shipping additionally to a mapped shipping method

### DIFF
--- a/src/Model/Carrier/Fix.php
+++ b/src/Model/Carrier/Fix.php
@@ -100,7 +100,8 @@ class Fix extends AbstractCarrier implements CarrierInterface
      */
     public function collectRates(RateRequest $request)
     {
-        if (!$this->sgOrder->getOrderNumber() || !$this->sgOrder->getShippingInfos()) {
+        if (!$this->sgOrder->getOrderNumber() || !$this->sgOrder->getShippingInfos()
+            || $this->sgOrder->getShippingType() === 'PLUGINAPI') {
             return false;
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

don't set shopgate Shipping additionally to a mapped shipping method

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I updated the CHANGELOG.md
