### PR TITLE
SG-175: fixed german translation in m2 admin

### DIFF
--- a/.github/workflows/check_and_deploy.yml
+++ b/.github/workflows/check_and_deploy.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Code Style
         run: |
-          curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.4.0/php-cs-fixer.phar -o php-cs-fixer
+          curl -L https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.16.0/php-cs-fixer.phar -o php-cs-fixer
           chmod a+x php-cs-fixer
           ./php-cs-fixer fix --config=.php-cs-fixer.dist.php --cache-file=.php-cs-fixer.cache --diff --dry-run --verbose
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- error when browsing to the Shopgate configuration page and using german language
 
 ## [2.9.32] - 2022-11-24
 ### Fixed

--- a/src/Setup/InstallSchema.php
+++ b/src/Setup/InstallSchema.php
@@ -53,16 +53,16 @@ class InstallSchema implements InstallSchemaInterface
                 'Entity ID'
             )->addColumn(
                 'order_id',
-                 Table::TYPE_INTEGER,
-                 null,
-                 ['unsigned' => true, 'nullable' => false, 'default' => '0'],
-                 'Order Id'
+                Table::TYPE_INTEGER,
+                null,
+                ['unsigned' => true, 'nullable' => false, 'default' => '0'],
+                'Order Id'
             )->addColumn(
                 'store_id',
-                 Table::TYPE_SMALLINT,
-                 null,
-                 ['unsigned' => true],
-                 'Store Id'
+                Table::TYPE_SMALLINT,
+                null,
+                ['unsigned' => true],
+                'Store Id'
             )->addColumn(
                 'shopgate_order_number',
                 Table::TYPE_TEXT,
@@ -106,10 +106,10 @@ class InstallSchema implements InstallSchemaInterface
                 Table::TYPE_TEXT
             )->addIndex(
                 $installer->getIdxName('shopgate_order', ['order_id']),
-                    ['order_id']
+                ['order_id']
             )->addIndex(
                 $installer->getIdxName('shopgate_order', ['store_id']),
-                    ['store_id']
+                ['store_id']
             )->addForeignKey(
                 $installer->getFkName('shopgate_order', 'order_id', 'sales_order', 'entity_id'),
                 'order_id',

--- a/src/i18n/de_DE.csv
+++ b/src/i18n/de_DE.csv
@@ -24,4 +24,4 @@
 "Duplicate entries were removed.","Doppelte Einträge wurden entfernt"
 "Mr.","Herr"
 "Ms.","Frau"
-"Note: Only one entry per prefix allowed.<br/>Prefixes must be configured first at:<br/>%s","Hinweis: Nur ein Eintrag pro Prefix erlaubt.<br/>Prefixe müssen zuerst hier Konfiguriert werden:<br/>%1"
+"Note: Only one entry per prefix allowed.<br/>Prefixes must be configured first at:<br/>%s","Hinweis: Nur ein Eintrag pro Prefix erlaubt.<br/>Prefixe müssen zuerst hier Konfiguriert werden:<br/>%s"


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes Shopgate Magento2 Configuration page when using German as Admin language.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
